### PR TITLE
Add timeout to dispatch event after setAnnotations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ class AnnotationServerStorage {
     async loadAnnotations() {
         const annotationPage: AnnotationPage = await this.adapter.all();
         this.anno.setAnnotations(annotationPage.items);
-        document.dispatchEvent(AnnoLoadEvent);
+        setTimeout(() => document.dispatchEvent(AnnoLoadEvent), 100);
     }
 
     /**

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -62,7 +62,8 @@ describe("Plugin instantiation", () => {
         const storage = new AnnotationServerStorage(clientMock, settings);
         await storage.loadAnnotations();
 
-        // Should dispatch the event "annotations-loaded"
+        // Should dispatch the event "annotations-loaded" after 100ms
+        await new Promise(res => setTimeout(res, 100));
         expect(dispatchEventSpy).toHaveBeenCalledWith(
             new Event("annotations-loaded"),
         );


### PR DESCRIPTION
Without this timeout, `annotorious-sas-storage` sometimes fires the `AnnoLoadEvent` early, before Annotorious has made data available via `getAnnotations`.

This is required due to https://github.com/recogito/annotorious-openseadragon/issues/126:

> I think I've come across this before. It looks like there's not much that can be done about out right now (given the way the zoom function currently works). Timeout might currently be your only workaround.
> 
> Some background: setAnnotations is not an async function. The effect you're seeing is that setAnnotations completes immediately, but the DOM update itself takes a while to process in the browser. The problem, now, is that fitAnnotations fetches the annotation from the DOM, and then fits the viewport.

Our code doesn't actually pull anything from the DOM AFAIK—it uses `getAnnotations()`—but since these are not asynchronous functions, it's not possible to tell exactly when they'll be available from Annotorious.