### PR TITLE
Add labels to annotations

### DIFF
--- a/src/types/V2/Annotation.ts
+++ b/src/types/V2/Annotation.ts
@@ -10,6 +10,7 @@ interface Annotation {
     "@context": string;
     "@type": string;
     "@id"?: string;
+    label?: string;
     motivation: string;
     on: Target;
     resource: Body | Body[];

--- a/src/types/V2/Annotation.ts
+++ b/src/types/V2/Annotation.ts
@@ -10,7 +10,6 @@ interface Annotation {
     "@context": string;
     "@type": string;
     "@id"?: string;
-    label?: string;
     motivation: string;
     on: Target;
     resource: Body | Body[];

--- a/src/types/V2/Body.ts
+++ b/src/types/V2/Body.ts
@@ -9,6 +9,7 @@ interface Body {
     chars: string;
     format?: string;
     language?: string;
+    label?: string;
 }
 
 export { Body };

--- a/src/types/V3/Annotation.ts
+++ b/src/types/V3/Annotation.ts
@@ -10,8 +10,9 @@ interface Annotation {
     "@context": string;
     body: Body | Body[];
     id?: string;
+    label?: string;
     motivation: string;
-    target: Target;   
+    target: Target;
     type: string;
 }
 

--- a/src/types/V3/Annotation.ts
+++ b/src/types/V3/Annotation.ts
@@ -10,7 +10,6 @@ interface Annotation {
     "@context": string;
     body: Body | Body[];
     id?: string;
-    label?: string;
     motivation: string;
     target: Target;
     type: string;

--- a/src/types/V3/Body.ts
+++ b/src/types/V3/Body.ts
@@ -9,6 +9,7 @@ interface Body {
     purpose?: string;
     format?: string;
     language?: string;
+    label?: string;
 }
 
 export { Body };

--- a/src/utils/SimpleAnnotationServerV2Adapter.ts
+++ b/src/utils/SimpleAnnotationServerV2Adapter.ts
@@ -159,6 +159,7 @@ export default class SimpleAnnotationServerV2Adapter {
                 full: (v3anno.target.source as Source).id,
             },
             resource,
+            label: v3anno.label,
         };
         if (v3anno.target.selector) {
             if (Array.isArray(v3anno.target.selector)) {
@@ -295,6 +296,7 @@ export default class SimpleAnnotationServerV2Adapter {
             "@context": "http://www.w3.org/ns/anno.jsonld",
             id: v2anno["@id"],
             motivation: "commenting",
+            label: v2anno.label,
             type: "Annotation",
             target,
             body,

--- a/src/utils/SimpleAnnotationServerV2Adapter.ts
+++ b/src/utils/SimpleAnnotationServerV2Adapter.ts
@@ -159,7 +159,6 @@ export default class SimpleAnnotationServerV2Adapter {
                 full: (v3anno.target.source as Source).id,
             },
             resource,
-            label: v3anno.label,
         };
         if (v3anno.target.selector) {
             if (Array.isArray(v3anno.target.selector)) {
@@ -208,6 +207,9 @@ export default class SimpleAnnotationServerV2Adapter {
         }
         if (v3body.language) {
             v2body.language = v3body.language;
+        }
+        if (v3body.label) {
+            v2body.label = v3body.label;
         }
         return v2body;
     }
@@ -296,7 +298,6 @@ export default class SimpleAnnotationServerV2Adapter {
             "@context": "http://www.w3.org/ns/anno.jsonld",
             id: v2anno["@id"],
             motivation: "commenting",
-            label: v2anno.label,
             type: "Annotation",
             target,
             body,
@@ -323,6 +324,9 @@ export default class SimpleAnnotationServerV2Adapter {
         }
         if (v2body["@type"] === "oa:Tag") {
             v3body.purpose = "tagging";
+        }
+        if (v2body.label) {
+            v3body.label = v2body.label;
         }
         return v3body;
     }


### PR DESCRIPTION
## In this PR

- Per https://github.com/Princeton-CDH/geniza/issues/915:
  - Persist `label` property in the annotation store by adding it to models and including it in conversions in both directions (V2 <--> V3)